### PR TITLE
updating widgets in development shouldnt require a recent commit

### DIFF
--- a/.gitmeta
+++ b/.gitmeta
@@ -989,7 +989,7 @@
 }, 
 "lib/g5_component_garden.rb": {
 "mode": 33188, 
-"mtime": 1421181305
+"mtime": 1421252044
 }, 
 "public/static/components/navigation/stylesheets/navigation.css": {
 "mode": 33188, 
@@ -1193,7 +1193,7 @@
 }, 
 "lib": {
 "mode": 16877, 
-"mtime": 1421181305
+"mtime": 1421252044
 }, 
 "public/static/components/column/images": {
 "mode": 16877, 
@@ -1605,7 +1605,7 @@
 }, 
 ".gitmeta": {
 "mode": 33188, 
-"mtime": 1421181229
+"mtime": 1421181370
 }, 
 "public/static/components/tour-form/index.html": {
 "mode": 33188, 

--- a/.gitmeta
+++ b/.gitmeta
@@ -61,7 +61,7 @@
 }, 
 "public/static/components/social-links": {
 "mode": 16877, 
-"mtime": 1420565214
+"mtime": 1419363207
 }, 
 "spec": {
 "mode": 16877, 
@@ -173,7 +173,7 @@
 }, 
 "public/static/components/coupon/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/promoted-reviews/stylesheets": {
 "mode": 16877, 
@@ -181,11 +181,11 @@
 }, 
 "public/static/components/self-storage-iui-cards/stylesheets": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1420051741
 }, 
 "public/static/components/navigation/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "public/static/components/button/index.html": {
 "mode": 33188, 
@@ -425,7 +425,7 @@
 }, 
 "public/static/components/featured-properties/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/city-state-zip-search/javascripts": {
 "mode": 16877, 
@@ -437,7 +437,7 @@
 }, 
 "public/static/components/floorplans-cards/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/self-storage-iui-filtered/images": {
 "mode": 16877, 
@@ -545,7 +545,7 @@
 }, 
 "public/static/components/gallery/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "public/static/components/column/index.html": {
 "mode": 33188, 
@@ -577,11 +577,11 @@
 }, 
 "public/static/components/social-links/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1420498772
 }, 
 "public/static/components/contact-info-sheet/javascripts/show": {
 "mode": 16877, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/comarketing/images": {
 "mode": 16877, 
@@ -641,7 +641,7 @@
 }, 
 "public/static/components/gallery-basic/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/floorplans-cards/stylesheets/floorplans-cards.css": {
 "mode": 33188, 
@@ -653,7 +653,7 @@
 }, 
 "public/static/components/locations-navigation/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1413488581
+"mtime": 1420556847
 }, 
 "public/static/components/hold-unit-form/index.html": {
 "mode": 33188, 
@@ -709,7 +709,7 @@
 }, 
 "public/static/components/multifamily-mini-search/javascripts/show": {
 "mode": 16877, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/hold-unit-form/show.html": {
 "mode": 33188, 
@@ -745,11 +745,11 @@
 }, 
 "public/static/components/footer-info/javascripts/show": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1420556847
 }, 
 "public/static/components/floorplans/javascripts/show": {
 "mode": 16877, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/google-translate/stylesheets": {
 "mode": 16877, 
@@ -785,11 +785,11 @@
 }, 
 "public/static/components/video/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/featured-properties/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/javascripts/libs/map-and-directions.js": {
 "mode": 33188, 
@@ -817,11 +817,11 @@
 }, 
 "public/static/components/social-links/javascripts": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1420498772
 }, 
 "public/static/components/city-state-zip-search/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1417653730
+"mtime": 1420556847
 }, 
 "db/schema.rb": {
 "mode": 33188, 
@@ -861,7 +861,7 @@
 }, 
 "public/static/components/coupon/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/locations-navigation/images/thumbnail.png": {
 "mode": 33188, 
@@ -873,7 +873,7 @@
 }, 
 "public/static/components/footer-info/javascripts": {
 "mode": 16877, 
-"mtime": 1409250169
+"mtime": 1421180834
 }, 
 "public/static/tmp-images/logo-4.png": {
 "mode": 33188, 
@@ -893,7 +893,7 @@
 }, 
 "public/static/components/promoted-reviews/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/review-form/show.html": {
 "mode": 33188, 
@@ -913,11 +913,11 @@
 }, 
 "public/static/components": {
 "mode": 16877, 
-"mtime": 1419905278
+"mtime": 1421179663
 }, 
 "public/static/components/home-multifamily-iui/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "app/assets/stylesheets": {
 "mode": 16877, 
@@ -953,7 +953,7 @@
 }, 
 "public/static/components/video/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "config/initializers/honeybadger.rb": {
 "mode": 33188, 
@@ -969,7 +969,7 @@
 }, 
 "public/static/components/phone/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1413488581
+"mtime": 1420556847
 }, 
 "public/static/components/social-links/images/thumbnail.png": {
 "mode": 33188, 
@@ -989,7 +989,7 @@
 }, 
 "lib/g5_component_garden.rb": {
 "mode": 33188, 
-"mtime": 1420051758
+"mtime": 1421181305
 }, 
 "public/static/components/navigation/stylesheets/navigation.css": {
 "mode": 33188, 
@@ -1005,7 +1005,7 @@
 }, 
 "public/static/components/footer-info/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1413488581
+"mtime": 1421180834
 }, 
 "public/static/components/contact-info/images/thumbnail.png": {
 "mode": 33188, 
@@ -1013,11 +1013,11 @@
 }, 
 "public/static/components/floorplans/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/self-storage-iui-cards/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "public/static/components/photo-group/stylesheets/photo-group.css": {
 "mode": 33188, 
@@ -1169,7 +1169,7 @@
 }, 
 "public/static/components/google-translate/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/lead-form/index.html": {
 "mode": 33188, 
@@ -1193,7 +1193,7 @@
 }, 
 "lib": {
 "mode": 16877, 
-"mtime": 1420055291
+"mtime": 1421181305
 }, 
 "public/static/components/column/images": {
 "mode": 16877, 
@@ -1205,7 +1205,7 @@
 }, 
 "public/static/components/social-links/show.html": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "public/static/components/service-request-form/edit.html": {
 "mode": 33188, 
@@ -1281,7 +1281,7 @@
 }, 
 "public/static/components/gallery/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "app/views/layouts/application.html.erb": {
 "mode": 33188, 
@@ -1289,11 +1289,11 @@
 }, 
 "public/static/components/floorplans-cards/javascripts/show": {
 "mode": 16877, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/column/javascripts/edit": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/floorplans-cards/stylesheets/jquery.fancybox.css": {
 "mode": 33261, 
@@ -1313,7 +1313,7 @@
 }, 
 "public/static/components/social-feed/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/contact-info-sheet/javascripts": {
 "mode": 16877, 
@@ -1329,7 +1329,7 @@
 }, 
 "lib/tasks/init_tasks.rake": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1420496453
 }, 
 "public/static/components/photo-group/edit.html": {
 "mode": 33188, 
@@ -1377,11 +1377,11 @@
 }, 
 "public/static/components/navigation/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "README.md": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1420496037
 }, 
 "public/static/components/home-multifamily-iui/edit.html": {
 "mode": 33188, 
@@ -1409,11 +1409,11 @@
 }, 
 "public/static/components/directions/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "public/static/components/phone/javascripts/show": {
 "mode": 16877, 
-"mtime": 1413488581
+"mtime": 1420556847
 }, 
 "public/static/components/apply-form/show.html": {
 "mode": 33188, 
@@ -1421,7 +1421,7 @@
 }, 
 "public/static/components/calls-to-action/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "public/static/components/multifamily-mini-search/index.html": {
 "mode": 33188, 
@@ -1513,7 +1513,7 @@
 }, 
 "public/static/components/gallery-basic/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/404.html": {
 "mode": 33188, 
@@ -1525,11 +1525,11 @@
 }, 
 "public/static/components/content-stripe/javascripts/edit": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/column/javascripts/edit.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/contact-form": {
 "mode": 16877, 
@@ -1541,7 +1541,7 @@
 }, 
 "public/static/components/self-storage-iui-cards/stylesheets/self-storage-iui-cards.css": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1420051741
 }, 
 "public/static/components/directions/stylesheets/directions.css": {
 "mode": 33188, 
@@ -1577,7 +1577,7 @@
 }, 
 "public/static/components/city-state-zip-search/javascripts/show": {
 "mode": 16877, 
-"mtime": 1417653730
+"mtime": 1420556847
 }, 
 "public/static/components/gallery-basic/images": {
 "mode": 16877, 
@@ -1585,7 +1585,7 @@
 }, 
 "public/static/components/home-multifamily-iui/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "vendor/assets/stylesheets": {
 "mode": 16877, 
@@ -1597,7 +1597,7 @@
 }, 
 "public/static/components/locations-navigation/javascripts/show": {
 "mode": 16877, 
-"mtime": 1413488581
+"mtime": 1420556847
 }, 
 "public/static/components/contact-info-sheet/index.html": {
 "mode": 33188, 
@@ -1605,7 +1605,7 @@
 }, 
 ".gitmeta": {
 "mode": 33188, 
-"mtime": 1420565312
+"mtime": 1421181229
 }, 
 "public/static/components/tour-form/index.html": {
 "mode": 33188, 
@@ -1617,7 +1617,7 @@
 }, 
 "public/static/components/calls-to-action/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "public/static/components/floorplans-cards/javascripts": {
 "mode": 16877, 
@@ -1665,7 +1665,7 @@
 }, 
 "public/static/components/footer-info": {
 "mode": 16877, 
-"mtime": 1420565220
+"mtime": 1419363521
 }, 
 "public/static/components/multifamily-mini-search/javascripts": {
 "mode": 16877, 
@@ -1685,7 +1685,7 @@
 }, 
 "public/static/components/multifamily-mini-search/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "lib/assets/.gitkeep": {
 "mode": 33188, 
@@ -1693,7 +1693,7 @@
 }, 
 "public/static/components/footer-info/stylesheets": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "public/static/components/button/show.html": {
 "mode": 33188, 
@@ -1833,7 +1833,7 @@
 }, 
 "public/static/components/contact-info-sheet/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/video/javascripts": {
 "mode": 16877, 
@@ -2081,7 +2081,7 @@
 }, 
 "public/static/components/footer-info/show.html": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1419363521
 }, 
 "app/helpers": {
 "mode": 16877, 
@@ -2137,7 +2137,7 @@
 }, 
 "lib/tasks": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1420496457
 }, 
 "public/static/components/html/images": {
 "mode": 16877, 
@@ -2161,7 +2161,7 @@
 }, 
 "public/static/components/contact-info/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1413488581
+"mtime": 1420556847
 }, 
 "public/static/components/corporate-map/show.html": {
 "mode": 33188, 
@@ -2193,11 +2193,11 @@
 }, 
 "public/static/components/promoted-reviews/javascripts/show": {
 "mode": 16877, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/social-links/stylesheets": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "app/assets/javascripts/application.js": {
 "mode": 33188, 
@@ -2209,7 +2209,7 @@
 }, 
 "public/static/components/self-storage-iui-cards/javascripts": {
 "mode": 16877, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "public/javascripts/libs/jquery.xdomainrequest.min.js": {
 "mode": 33188, 
@@ -2277,7 +2277,7 @@
 }, 
 "public/static/components/directions/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416936348
+"mtime": 1420556847
 }, 
 "package.json": {
 "mode": 33188, 
@@ -2349,7 +2349,7 @@
 }, 
 "public/static/components/content-stripe/javascripts/edit.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/phone/show.html": {
 "mode": 33188, 
@@ -2361,7 +2361,7 @@
 }, 
 "public/static/components/social-feed/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/javascripts": {
 "mode": 16877, 
@@ -2369,7 +2369,7 @@
 }, 
 "public/static/components/footer-info/stylesheets/footer-info.css": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "public/static/components/city-state-zip-search/images": {
 "mode": 16877, 
@@ -2441,7 +2441,7 @@
 }, 
 "public/static/components/social-links/stylesheets/social-links.css": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1419363207
 }, 
 "public/static/components/contact-info/images": {
 "mode": 16877, 
@@ -2461,7 +2461,7 @@
 }, 
 "public/static/components/footer-info/javascripts/show/show.js.coffee": {
 "mode": 33188, 
-"mtime": 1420498778
+"mtime": 1409250169
 }, 
 "config/initializers/wrap_parameters.rb": {
 "mode": 33188, 
@@ -2561,11 +2561,11 @@
 }, 
 "public/static/components/google-translate/javascripts/show": {
 "mode": 16877, 
-"mtime": 1419363207
+"mtime": 1420556847
 }, 
 "public/static/components/contact-info/javascripts/show": {
 "mode": 16877, 
-"mtime": 1413488581
+"mtime": 1420556847
 }, 
 "public/static/components/html/show.html": {
 "mode": 33188, 
@@ -2657,7 +2657,7 @@
 }, 
 "public/static/components/map/javascripts/show": {
 "mode": 16877, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/map": {
 "mode": 16877, 
@@ -2681,7 +2681,7 @@
 }, 
 "public/static/components/map/javascripts/show.js": {
 "mode": 33188, 
-"mtime": 1416247185
+"mtime": 1420556847
 }, 
 "public/static/components/featured-properties/javascripts": {
 "mode": 16877, 

--- a/lib/g5_component_garden.rb
+++ b/lib/g5_component_garden.rb
@@ -106,6 +106,7 @@ module G5ComponentGarden
     end
 
     def get_directory_timestamp(directory)
+      return 5.seconds.ago if Rails.env.development?
       Time.zone.at(META[directory]['mtime'])
     end
 

--- a/lib/g5_component_garden.rb
+++ b/lib/g5_component_garden.rb
@@ -106,7 +106,7 @@ module G5ComponentGarden
     end
 
     def get_directory_timestamp(directory)
-      return 5.seconds.ago if Rails.env.development?
+      return 5.seconds.ago if ENV['FORCE_WIDGET_UPDATES']
       Time.zone.at(META[directory]['mtime'])
     end
 


### PR DESCRIPTION
We need to update widgets regardless of commit history in development mode. Otherwise we're going to end up with a bunch of garbage commits in the history just for the sake of making widgets update. 