### PR TITLE
changing spelling of duel to dual

### DIFF
--- a/public/static/components/corporate-map/edit.html
+++ b/public/static/components/corporate-map/edit.html
@@ -36,7 +36,7 @@
       {% endif %}
     />
     <label for="{{ widget.state_data_toggle.value_field_id }}" >
-      Duel Maps?  
+      Dual Maps?
     </label>
   </div>
 

--- a/public/static/components/corporate-map/index.html
+++ b/public/static/components/corporate-map/index.html
@@ -25,7 +25,7 @@
               <dd class="p-g5-default-value"></dd>
             </dl>
           </dd>
-            
+
           <dd class="e-g5-property h-g5-property">
             <dl>
               <dt>Core Client Id</dt>
@@ -50,7 +50,7 @@
 
           <dd class="e-g5-property h-g5-property">
             <dl>
-              <dt>Duel Maps</dt>
+              <dt>Dual Maps</dt>
               <dd class="p-g5-name">state_data_toggle</dd>
               <dt>Editable</dt>
               <dd class="p-g5-editable">true</dd>
@@ -61,7 +61,7 @@
 
           <dd class="e-g5-property h-g5-property">
             <dl>
-              <dt>Core Client Id 2 (when duel maps checked)</dt>
+              <dt>Core Client Id 2 (when dual maps checked)</dt>
               <dd class="p-g5-name">core_client_id_alt</dd>
               <dt>Editable</dt>
               <dd class="p-g5-editable">true</dd>


### PR DESCRIPTION
Pretty straight forward spelling change.

### PT Story:

https://www.pivotaltracker.com/story/show/85824358

### Testing Notes:

Go to following cloned cms app and choose the first content stripe, edit the Corp Locations Map widget. See correct spelling of 'dual'.

https://aaron-vision-health.herokuapp.com/vision-health/home/edit
